### PR TITLE
Remove useless interpolation in Spanish locale

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -395,7 +395,7 @@ es:
         project_link: "Ver proyecto"
         techno: "Creado con"
         cta: "¡Solicita ahora!"
-      batch_title: " changemakers de la Promoción #%{batch_slug} "
+      batch_title: " changemakers"
   students:
     index:
       meta_title: "Opiniones sobre Le Wagon y casos de éxito bootcamp de programación | Le Wagon Alumni"


### PR DESCRIPTION
No argument given to the locale 
https://github.com/ClaraMorgen/www/blob/4a806198330d2fbc47cbf3ab32f18035b144e7a3/app/views/demoday/_batch_demoday.html.erb#L50

was printing the interpolation without interpolating 👇 
<img width="1276" alt="bildschirmfoto 2017-11-30 um 10 53 47" src="https://user-images.githubusercontent.com/29435293/33425309-a1969802-d5be-11e7-97cf-a7c864165c7a.png">
